### PR TITLE
workaround for config issue in grails3

### DIFF
--- a/src/main/groovy/grails/plugins/mail/MailGrailsPlugin.groovy
+++ b/src/main/groovy/grails/plugins/mail/MailGrailsPlugin.groovy
@@ -87,9 +87,6 @@ sendMail {
         } 
     }
     
-
-
-
     void onConfigChange(Map<String, Object> event) {
         ConfigObject newMailConfig = event.source.grails.mail
         Integer newMailConfigHash = newMailConfig.hashCode()
@@ -127,6 +124,12 @@ sendMail {
                 createdSession = false
             }
 
+            /*
+            * This is the workaround to convert nested map of mail config props to single level map with dots in keys.
+            * eg: [a: [b: 'c']  -> [ 'a.b': 'c']
+            * */
+            config.props = convertNestedMapToSingleLevelMap(config.props)
+
             mailSender(JavaMailSenderImpl) {
                 if (config.host) {
                     host = config.host
@@ -161,4 +164,25 @@ sendMail {
         }
     }
 
+    static Map convertNestedMapToSingleLevelMap(Map inputMap) {
+        inputMap?.inject([:]) { Map m, key, value ->
+            if (value instanceof Map) {
+                m.putAll(convertMapToSingleLevel(key, value))
+            } else {
+                m.put(key, value)
+            }
+            m
+        } as Map
+    }
+
+    static Map convertMapToSingleLevel(String parentKey, Map mapValue) {
+        mapValue?.inject([:]) { Map singleLevelMap, key, value ->
+            if (value instanceof Map) {
+                singleLevelMap.putAll convertMapToSingleLevel("$parentKey.$key", value)
+            } else {
+                singleLevelMap.put("$parentKey.$key", value)
+            }
+            singleLevelMap
+        } as Map
+    }
 }

--- a/src/test/groovy/grails/plugins/mail/MailGrailsPluginTests.groovy
+++ b/src/test/groovy/grails/plugins/mail/MailGrailsPluginTests.groovy
@@ -36,6 +36,17 @@ class MailGrailsPluginTests extends GroovyTestCase {
                  'mail.smtp.socketFactory.port'    : 465,
                  'mail.smtp.socketFactory.class'   : 'javax.net.ssl.SSLSocketFactory',
                  'mail.smtp.socketFactory.fallback': 'false'])
+        compare(
+            convertNestedMapToSingleLevelMap(['mail.smtp.auth'                  : true,
+                 'mail.smtp.socketFactory.port'    : 465,
+                 'mail.smtp.socketFactory.class'   : 'javax.net.ssl.SSLSocketFactory',
+                 'mail.smtp.socketFactory.fallback': 'false']),
+            
+                ['mail.smtp.auth'                  : true,
+                 'mail.smtp.socketFactory.port'    : 465,
+                 'mail.smtp.socketFactory.class'   : 'javax.net.ssl.SSLSocketFactory',
+                 'mail.smtp.socketFactory.fallback': 'false']
+        )
     }
 
     void testConvertMapToSingleLevel() {

--- a/src/test/groovy/grails/plugins/mail/MailGrailsPluginTests.groovy
+++ b/src/test/groovy/grails/plugins/mail/MailGrailsPluginTests.groovy
@@ -1,0 +1,51 @@
+package grails.plugins.mail
+
+import static grails.plugins.mail.MailGrailsPlugin.convertMapToSingleLevel
+import static grails.plugins.mail.MailGrailsPlugin.convertNestedMapToSingleLevelMap
+
+/**
+ * Test case for {@link MailGrailsPlugin}.
+ * @author Puneet Behl
+ */
+class MailGrailsPluginTests extends GroovyTestCase {
+    void testCanary() {
+        assertEquals true, true
+    }
+
+
+    void testConvertNestedMapToSingleLevelMap() {
+        compare convertNestedMapToSingleLevelMap([a: [b: 'c']]), ['a.b': 'c']
+        compare convertNestedMapToSingleLevelMap([x: 'y']), [x: 'y']
+        compare(convertNestedMapToSingleLevelMap(
+                [
+                        mail:
+                                [
+                                        smtp:
+                                                [
+                                                        auth         : true,
+                                                        socketFactory:
+                                                                [
+                                                                        port    : 465,
+                                                                        class   : 'javax.net.ssl.SSLSocketFactory',
+                                                                        fallback: false
+                                                                ]
+                                                ]
+                                ]
+                ]),
+                ['mail.smtp.auth'                  : true,
+                 'mail.smtp.socketFactory.port'    : 465,
+                 'mail.smtp.socketFactory.class'   : 'javax.net.ssl.SSLSocketFactory',
+                 'mail.smtp.socketFactory.fallback': 'false'])
+    }
+
+    void testConvertMapToSingleLevel() {
+        compare convertMapToSingleLevel('x', [a: 1, b: 2]), ['x.a': 1, 'x.b': 2]
+        compare convertMapToSingleLevel('x', [a: 1, b: [c: 2, d: 3]]), ['x.a': 1, 'x.b.c': 2, 'x.b.d': 3]
+        compare convertMapToSingleLevel('x', [a: 1, b: [c: [d: 3]]]), ['x.a': 1, 'x.b.c.d': 3]
+    }
+
+    static void compare(result, expected) {
+        assertEquals expected.toString(), result.toString()
+    }
+
+}


### PR DESCRIPTION
The Mail plugin is not working with Grails-3.0.1, It seems like the issue is with ```props: []``` in mail configuration and ```javaMailProperties``` is not set properly for ```JavaMailSenderImpl``` due to
```
props: [
 'mail.smtp.auth'                  : true,
 'mail.smtp.socketFactory.port'    : 465,
 'mail.smtp.socketFactory.class'   : 'javax.net.ssl.SSLSocketFactory',
 'mail.smtp.socketFactory.fallback': 'false'
]
```
is transformed into 
```
props: [ mail: [ smtp: [ auth : true, socketFactory: [ port:465, class: 'javax.net.ssl.SSLSocketFactory', fallback: 'false' ] ] ] ]
```
Here is the github link for the workaround I've implemented https://github.com/puneetbehl/mail/commit/caa33402c41f6ebfe25e54e46f9bcb8b00e8d3cc