### PR TITLE
workaround for config issue in grails3 

### DIFF
--- a/src/main/groovy/grails/plugins/mail/MailGrailsPlugin.groovy
+++ b/src/main/groovy/grails/plugins/mail/MailGrailsPlugin.groovy
@@ -156,7 +156,7 @@ sendMail {
                 if (config.protocol)
                     protocol = config.protocol
                 if (config.props instanceof Map && config.props)
-                    javaMailProperties = config.props
+                    javaMailProperties = config.props.toFlatConfig()
             }
         }
     }


### PR DESCRIPTION
The yml parser doesn't produces a nested map when a key contains dots.
For the mail props to work it needs to be flat.