### PR TITLE
Option to set subject and text by message code

### DIFF
--- a/src/main/groovy/grails/plugins/mail/MailMessageBuilder.groovy
+++ b/src/main/groovy/grails/plugins/mail/MailMessageBuilder.groovy
@@ -19,6 +19,7 @@ import com.sun.mail.smtp.SMTPMessage
 import grails.config.Config
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+import org.springframework.context.MessageSource
 import org.springframework.core.io.ByteArrayResource
 import org.springframework.core.io.FileSystemResource
 import org.springframework.core.io.InputStreamSource
@@ -55,6 +56,7 @@ class MailMessageBuilder {
     private MailMessage message
     private MimeMessageHelper helper
     private Locale locale
+    private MessageSource messageSource
 
     private String textContent
     private String htmlContent
@@ -71,9 +73,10 @@ class MailMessageBuilder {
         InputStreamSource toAdd
     }
 
-    MailMessageBuilder(MailSender mailSender, Config config, MailMessageContentRenderer mailMessageContentRenderer = null) {
+    MailMessageBuilder(MailSender mailSender, Config config, MailMessageContentRenderer mailMessageContentRenderer = null, MessageSource messageSource = null) {
         this.mailSender = mailSender
         this.mailMessageContentRenderer = mailMessageContentRenderer
+        this.messageSource = messageSource
 
         this.overrideAddress = config.getProperty('grails.mail.overrideAddress')
         this.defaultFrom = overrideAddress ?: config.getProperty('grails.mail.default.from')
@@ -135,6 +138,15 @@ class MailMessageBuilder {
         }
 
         message
+    }
+
+    void messageSource(MessageSource messageSource) {
+        this.messageSource = messageSource
+    }
+
+    String message(String code, Object... args) {
+        Assert.notNull(messageSource, "no messageSource set")
+        messageSource.getMessage(code, args, locale)
     }
 
     void multipart(boolean multipart) {

--- a/src/main/groovy/grails/plugins/mail/MailMessageBuilderFactory.groovy
+++ b/src/main/groovy/grails/plugins/mail/MailMessageBuilderFactory.groovy
@@ -17,6 +17,7 @@ package grails.plugins.mail
 
 import grails.config.Config
 import groovy.transform.CompileStatic
+import org.springframework.context.MessageSource
 import org.springframework.mail.MailSender
 import org.springframework.mail.javamail.JavaMailSender
 
@@ -29,9 +30,10 @@ class MailMessageBuilderFactory {
 
     MailSender mailSender
     MailMessageContentRenderer mailMessageContentRenderer
+    MessageSource messageSource
 
     MailMessageBuilder createBuilder(Config config) {
-        new MailMessageBuilder(mailSender, config, mailMessageContentRenderer)
+        new MailMessageBuilder(mailSender, config, mailMessageContentRenderer, messageSource)
     }
 
     boolean isMimeCapable() {

--- a/src/test/groovy/grails/plugins/mail/MailMessageBuilderSpec.groovy
+++ b/src/test/groovy/grails/plugins/mail/MailMessageBuilderSpec.groovy
@@ -17,6 +17,7 @@ package grails.plugins.mail
 
 import grails.test.mixin.TestMixin
 import grails.test.mixin.support.GrailsUnitTestMixin
+import org.springframework.context.support.StaticMessageSource
 import org.springframework.mail.MailSender
 import org.springframework.mail.javamail.JavaMailSender
 import org.springframework.web.context.support.ServletContextResource
@@ -276,6 +277,27 @@ class MailMessageBuilderSpec extends Specification {
 		}
 		then:
 		thrown(FileNotFoundException)
+	}
+
+	void "Test subject and text codes using message source"() {
+		setup:
+		def staticMessageSource = new StaticMessageSource()
+		staticMessageSource.addMessages([
+				'mail.subject': 'Hallo {0}',
+				'mail.text': 'Wie geht es dir?'
+		], Locale.GERMAN)
+
+		when:
+		processDsl {
+			messageSource staticMessageSource
+			locale Locale.GERMAN
+			subject message('mail.subject', 'Fred')
+			text message('mail.text')
+		}
+		then:
+		def msg = testJavaMailSenderBuilder.message.mimeMessage
+		msg.subject == 'Hallo Fred'
+		msg.content == 'Wie geht es dir?'
 	}
 
 	@Issue("for issue GPMAIL-60")


### PR DESCRIPTION
I tried implementing my feature suggestion from issue https://github.com/grails3-plugins/mail/issues/22 to allow for an easy way to set mail subject and text by a message code, also considering the the already existing locale option from the mail dsl.

Example usage:
```
mailService.sendMail {
    locale user.languageForCorrespondence
    subject message('mail.summary.subject')
    text message('mail.summary.text')
}
```