### PR TITLE
Re-order ThreadPool settings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ plugins {
     id "com.jfrog.bintray" version "1.2"
 }
 
-version "2.0.0"
+version "2.0.1"
 group "org.grails.plugins"
 
 apply plugin: 'maven-publish'

--- a/grails-app/services/grails/plugins/mail/MailService.groovy
+++ b/grails-app/services/grails/plugins/mail/MailService.groovy
@@ -63,8 +63,8 @@ class MailService implements InitializingBean, DisposableBean, GrailsConfigurati
     }
 
 	void setPoolSize(Integer poolSize){
-		mailExecutorService.setCorePoolSize(poolSize ?: DEFAULT_POOL_SIZE)
 		mailExecutorService.setMaximumPoolSize(poolSize ?: DEFAULT_POOL_SIZE)
+		mailExecutorService.setCorePoolSize(poolSize ?: DEFAULT_POOL_SIZE)
 	}
 
 	@Override


### PR DESCRIPTION
Re-order ThreadPool settings so that the maximum pool size is set before the core pool size. Fixes an exception in JDK 10. Fixes #31 