### PR TITLE
spida initial fixes to mailSender and toFlatConfig

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-grailsVersion=4.0.0
+grailsVersion=4.0.10
 vcsUrl=https://github.com/grails3-plugins/mail/

--- a/src/main/groovy/grails/plugins/mail/MailGrailsPlugin.groovy
+++ b/src/main/groovy/grails/plugins/mail/MailGrailsPlugin.groovy
@@ -153,8 +153,10 @@ sendMail {
                     password = config.password
                 if (config.protocol)
                     protocol = config.protocol
-                if (config.props instanceof Map && config.props)
+                if (config.props instanceof org.grails.config.NavigableMap && config.props)
                     javaMailProperties = config.props.toFlatConfig()
+                if (config.props instanceof Map && config.props)
+                    javaMailProperties = config.props
             }
         }
     }

--- a/src/main/groovy/grails/plugins/mail/MailMessageBuilder.groovy
+++ b/src/main/groovy/grails/plugins/mail/MailMessageBuilder.groovy
@@ -45,7 +45,7 @@ class MailMessageBuilder {
 
     private static final Logger log = LoggerFactory.getLogger(MailMessageBuilder.class)
 
-    final MailSender mailSender
+    MailSender mailSender
     final MailMessageContentRenderer mailMessageContentRenderer
 
     final String defaultFrom
@@ -105,7 +105,7 @@ class MailMessageBuilder {
         MailMessage message = finishMessage()
 
         if (log.traceEnabled) {
-            log.trace("Sending mail ${getDescription(message)}} ...")
+            log.trace("Sending mail ${getDescription(message)} ...")
         }
 
         def sendingMsg = message instanceof MimeMailMessage ? message.mimeMessage : message
@@ -117,7 +117,10 @@ class MailMessageBuilder {
             sendingMsg = new SMTPMessage(sendingMsg)
             sendingMsg.envelopeFrom = envelopeFrom
         }
-
+        
+		//MailGrailsPlugin.groovy removes and recreates the mailSender on config change
+		//mailSender can be null if we don't do this after a config change
+		mailSender = grails.util.Holders.grailsApplication.mainContext.getBean("mailSender")
 		if(async){
 			executorService.execute({
 				try{


### PR DESCRIPTION
I was running into two different errors.
1.  the toFlatConfig method is not available on a normal Map
2. the mailSender was null after onConfigChange was called

I'm sure if you want these fixes but they fix our issues.