### PR TITLE
added GSP Configuration for Grails 3.3+

### DIFF
--- a/src/docs/guide/2.3 Other Configuration.gdoc
+++ b/src/docs/guide/2.3 Other Configuration.gdoc
@@ -17,3 +17,26 @@ An alternative to disabling email or using something like the "greenmail plugin"
 {code}
 grails.mail.overrideAddress = "test@address.com"
 {code}
+
+h3. GSP Configuration
+
+If you're using GSP views to render HTML emails, you will need to configure the GSP plugin. 
+
+GSP was previously part of Grails core, but since version 3.3 it is an independent Grails plugin that can be used by defining the following dependency in your build.gradle:
+
+build.gradle
+
+{code}
+dependencies {
+    ...
+    implementation "org.grails.plugins:gsp:5.0.1"
+}
+{code}
+
+In addition for production compilation you should apply the grails-gsp Gradle plugin:
+
+build.gradle
+
+{code}
+apply plugin:"org.grails.grails-gsp"
+{code}


### PR DESCRIPTION
If you use GSP views with the Grails Mail plugin in Grails 3.3 or higher, you need to configure the GSP plugin for the views to render properly. See also: https://stackoverflow.com/questions/69993899/grails-4-mail-plugin-illegalargumentexception-could-not-locate-mail-body/69993900