### PR TITLE
build(ci): Fix problem with multi-line run commands

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -45,25 +45,29 @@ jobs:
       - uses: actions/setup-java@v4
         with: { java-version: 11, distribution: temurin }
       - uses: gradle/actions/setup-gradle@v3
+
       - name: Build Project
         env:
           DEVELOCITY_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
         run: ./gradlew build
+
       - name: Publish Snapshot version to Artifactory (repo.grails.org)
         if: success()
         env:
           DEVELOCITY_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
           ORG_GRADLE_PROJECT_artifactoryPublishUsername: ${{ secrets.ARTIFACTORY_USERNAME }}
           ORG_GRADLE_PROJECT_artifactoryPublishPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
-        run: |
+        run: >
           ./gradlew
           -Dorg.gradle.internal.publish.checksums.insecure=true
           publish
+
       - name: Generate Snapshot Documentation
         if: success()
         env:
           DEVELOCITY_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
         run: ./gradlew docs
+
       - name: Publish Snapshot Documentation to Github Pages
         if: success()
         uses: micronaut-projects/github-pages-deploy-action@grails

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ jobs:
       - uses: gradle/wrapper-validation-action@v2
       - uses: actions/setup-java@v4
         with: { java-version: 11, distribution: temurin }
+      - uses: gradle/actions/setup-gradle@v3
 
       - name: Get the current release version
         id: release_version
@@ -30,7 +31,6 @@ jobs:
 
       - name: Publish artifacts to Sonatype
         id: publish_to_sonatype
-        uses: gradle/actions/setup-gradle@v3
         env:
           DEVELOCITY_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
           ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.SONATYPE_USERNAME }}
@@ -38,19 +38,17 @@ jobs:
           ORG_GRADLE_PROJECT_sonatypeStagingProfileId: ${{ secrets.SONATYPE_STAGING_PROFILE_ID }}
           SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
           SIGNING_PASSPHRASE: ${{ secrets.SIGNING_PASSPHRASE }}
-        with:
-          arguments: |
-            -Psigning.secretKeyRingFile=${{ github.workspace }}/secring.gpg
-            publishToSonatype
-            closeAndReleaseSonatypeStagingRepository
+        run: >
+          ./gradlew
+          -Psigning.secretKeyRingFile=${{ github.workspace }}/secring.gpg
+          publishToSonatype
+          closeAndReleaseSonatypeStagingRepository
 
       - name: Generate Documentation
         if: success()
-        uses: gradle/actions/setup-gradle@v3
         env:
           DEVELOCITY_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
-        with:
-          arguments: docs
+        run: ./gradlew docs
 
       - name: Publish Documentation to Github Pages
         if: success()


### PR DESCRIPTION
Using | for Github Actions multi-line run command will keep the newlines and does not work with running ./gradlew. Using > replaces newline with spaces.

This commit also replaces the deprecated usage of `setup-gradle` `with arguments` in release.yml.