### PR TITLE
build(docs): Fix docs generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,6 @@ target-eclipse/
 *.log
 test/reports
 target
-docs
 .DS_Store
 plugin.xml
 *.zip

--- a/src/docs/guide.properties
+++ b/src/docs/guide.properties
@@ -1,0 +1,2 @@
+title=Grails Mail Plugin
+authors=The Grails Team


### PR DESCRIPTION
- Remove `docs` dir from `.gitignore`
- Add file with guide properties